### PR TITLE
Stereo data

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -37,17 +37,19 @@ void drawBuffers(OpenMpt openMpt) {
   ModPosition pos = openMpt.getModPosition();
   List<List<String>> allPatterns = openMpt.getAllPatterns();
   StereoAudioBuffers buffers = openMpt.getStereoAudioBuffers();
-  print('Song Title -> ${openMpt.modInfo.title.toDartString()}\n');
 
   int numCols = stdout.terminalColumns - 1,
-      numRows = stdout.terminalLines - 9;
+      numRows = stdout.terminalLines - 10;
 
-  // Clear the screen IF we end up not
+  // Clear the screen IF we end up resizing the terminal
   if (numCols != prevColumns || numRows != prevRows) {
     print("\x1B[2J\x1B[0;0H");
   }
 
+  prevColumns = numCols;
+  prevRows = numRows;
 
+  print('Song Title -> ${openMpt.modInfo.title.toDartString()}');
 
   if (pos.current_order != prevOrd || pos.current_pattern != prevPat || pos.current_row != prevRow) {
     // move positions of items
@@ -70,13 +72,13 @@ void drawBuffers(OpenMpt openMpt) {
   prevRow = pos.current_row;
 
 
-
   print(fiveTrailingPatterns[0]);
   print(fiveTrailingPatterns[1]);
   print(fiveTrailingPatterns[2]);
   print(fiveTrailingPatterns[3]);
   print(blueBgPen(fiveTrailingPatterns[4]));
   print('');
+  
   List<List<String>> screenBuffer = [];
   String emptyString = ' ';
 
@@ -205,12 +207,20 @@ Future<void> main(List<String> args) async {
   // Move Cursor 0,0
   print("\x1B[2J\x1B[0;0H");
 
-  final Duration posTimer = Duration(milliseconds: 20);
   while (true) {
+
     if (shouldContinue) {
+      final stopwatch = Stopwatch()..start();
       drawBuffers(openMpt);
-      await Future.delayed(posTimer);
-      sleep(posTimer);
+      // print('drawBuffers() executed in ${stopwatch.elapsed.inMilliseconds}');
+      if (stopwatch.elapsed.inMilliseconds < 20) {
+        int diff = 20 - stopwatch.elapsed.inMilliseconds;
+        // sleep ONLY if we need to.
+        if (diff > 0) {
+          sleep(Duration(milliseconds: diff));
+        }
+      }
+
     }
   }
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -13,10 +13,11 @@ AnsiPen grayPen = new AnsiPen()..gray();
 
 AnsiPen blueBgPen = new AnsiPen()..blue(bg:true);
 
-final leftDot = bluePen('█');
-final rightDot = redPen('█');
-final purpleDot = redPen('█');
-final hyphen = grayPen('─');
+final String leftDot = bluePen('▒');
+final String rightDot = redPen('▒');
+// final String purpleDot = redPen('█');
+final String hyphen = grayPen('─');
+final String pipeChar = grayPen('│');
 // print('col:${col} | row:${rowNum} | yPos:${yPos} | xPos:${xPos} | leftAvg:${leftAverage}');
 //https://www.bbc.co.uk/bitesize/guides/zscvxfr/revision/4
 // ▓ ▒ ░
@@ -78,6 +79,9 @@ void drawBuffers(OpenMpt openMpt) {
   print(fiveTrailingPatterns[3]);
   print(blueBgPen(fiveTrailingPatterns[4]));
   print('');
+
+  //TODO: Investigate reuse versus recreation/destruction everytime
+  //      this function is run.
   
   List<List<String>> screenBuffer = [];
   String emptyString = ' ';
@@ -88,6 +92,7 @@ void drawBuffers(OpenMpt openMpt) {
 
   // Create memory space to act as a screen buffer
   // (could not figure out a way to do this en mass)
+
   for (int rowNum = 0; rowNum < numRows; rowNum++) {
     List<String> row = [];
     for (int col = 0; col < numCols; col++) {
@@ -97,7 +102,7 @@ void drawBuffers(OpenMpt openMpt) {
         str = hyphen;
       }
       if (col == halfX) {
-        str = '│';
+        str = pipeChar;
       }
       row.add(str);
     }

--- a/lib/OpenMPT/src/OpenMPT.cpp
+++ b/lib/OpenMPT/src/OpenMPT.cpp
@@ -169,9 +169,10 @@ int main(int argc, char *argv[]) {
     printf("modInfo.title = %s\n", modInfo.title);
     play_music();
 
-    for (int patNum = 0; patNum < modInfo.num_patterns; ++patNum) {
-      SoundManager::GetPattern(patNum);
+//    SoundManager::GetAll
 
+    for (int patNum = 0; patNum < modInfo.num_patterns; ++patNum) {
+       SoundManager::GetPattern(patNum);
     }
 
 //    SoundManager::GetPattern(0);


### PR DESCRIPTION
### Change

- [x] Fixed sound buffer copy code. Left and right are truly the proper data.
- [x] Created Stereo Separation in the waveform rendering chart
- [x] Added FPS throttling logic to example.dart so that smaller songs don't render too fast.
- [x] Waveform character uses `▒` instead of `█` so the colors are not so bright.
- [x] Upon resize of the terminal, we'll trim strings for the pattern data as well as clear the screen.

![image](https://user-images.githubusercontent.com/180031/118181767-2811f100-b406-11eb-8c1f-a7fd8207287c.png)
