### PR TITLE
added requirement argument to external call

### DIFF
--- a/lib/OpenMPT/src/OpenMPT.cpp
+++ b/lib/OpenMPT/src/OpenMPT.cpp
@@ -49,7 +49,7 @@ int shutdown() {
 }
 
 void freeArrayOfStrings(ArrayOfStrings *arrayOfStrings) {
-  SoundManager::FreeArrayOfStrings();
+  SoundManager::FreeArrayOfStrings(arrayOfStrings);
 }
 
 


### PR DESCRIPTION
### Change

When trying to compile OpenMPT on MacOS Big Sur (11.5.1) the compile failed with the following error message:

/Users/hhalfpap/git/dart-mod-player/lib/OpenMPT/src/OpenMPT.cpp:52:36: error: too few arguments to function call, single argument 'arrayOfStrings' was not specified
  SoundManager::FreeArrayOfStrings();
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^

After passing the argument "arrayOfStrings" the lib compiled successfully

### Does this PR introduce a breaking change?

Hopefully not.

### What needs to be documented once your changes are merged?

Probably nothing / bug fix

### Additional Comments

n/a
